### PR TITLE
Feature: Add Manage Command

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -25,6 +25,14 @@
   },
   {
     "alias": [],
+    "command": "simply:package:dependencies:manage",
+    "flagAliases": [],
+    "flagChars": ["b", "v"],
+    "flags": ["api-version", "branch", "flags-dir", "json", "target-dev-hub", "update-to-latest", "update-to-released"],
+    "plugin": "@simplysf/simply-package"
+  },
+  {
+    "alias": [],
     "command": "simply:package:version:cleanup",
     "flagAliases": [],
     "flagChars": ["p", "s", "v"],

--- a/messages/simply.package.dependencies.manage.md
+++ b/messages/simply.package.dependencies.manage.md
@@ -1,0 +1,86 @@
+# summary
+
+Manage package dependency versions for a Salesforce project.
+
+# description
+
+Interactively updates package dependency versions in sfdx-project.json by querying the Dev Hub for available versions. Supports interactive selection or automatic update to the latest released or latest build version.
+
+Project-level configuration (in sfdx-project.json) is read from the following keys:
+
+- plugins.simply.dependencies.ignore — array of Package2Ids or aliases to leave unchanged
+- plugins.simply.package.brancheswithreleasedversions — array of branch names that contain released versions
+
+# flags.branch.summary
+
+Package branch to consider when evaluating version options.
+
+# flags.branch.description
+
+When specified, the command will include the latest build on this branch as a selectable option for each dependency.
+
+# flags.update-to-released.summary
+
+Automatically update all dependencies to the latest released version.
+
+# flags.update-to-released.description
+
+When specified, all dependencies managed by the Dev Hub are automatically updated to the latest released package version without interactive prompts. Mutually exclusive with --update-to-latest.
+
+# flags.update-to-latest.summary
+
+Automatically set all dependencies to the latest non-pinned build.
+
+# flags.update-to-latest.description
+
+When specified, all dependencies managed by the Dev Hub are automatically set to a non-pinned X.Y.Z.LATEST version number without interactive prompts. Mutually exclusive with --update-to-released.
+
+# examples
+
+- <%= config.bin %> <%= command.id %> --target-dev-hub myDevHub
+
+- <%= config.bin %> <%= command.id %> --target-dev-hub myDevHub --branch my-feature-branch
+
+- <%= config.bin %> <%= command.id %> --target-dev-hub myDevHub --update-to-released
+
+- <%= config.bin %> <%= command.id %> --target-dev-hub myDevHub --update-to-latest
+
+# info.loadingDevHubData
+
+Loading package information from Dev Hub...
+
+# info.analyzingDependencies
+
+Analyzing project dependencies...
+
+# info.reviewingDependency
+
+Preparing options for dependency '%s'
+
+# info.dependencyNotManagedByDevHub
+
+The dependency '%s' is not managed by this Dev Hub. Skipping.
+
+# info.noAlternatesFound
+
+No alternate version options found for '%s'.
+
+# info.versionSelected
+
+%s version selected: %s
+
+# info.versionIgnored
+
+%s version is ignored (no change applied).
+
+# prompt.selectVersion
+
+Which version of package '%s' should be used?
+
+# errors.connectionFailed
+
+Unable to establish connection to the Dev Hub org.
+
+# errors.noProjectDependencies
+
+No package dependencies with dev hub-managed packages were found in sfdx-project.json.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@salesforce/kit": "^3.2.6",
     "@salesforce/packaging": "^4.22.16",
     "@salesforce/sf-plugins-core": "^12.2.16",
+    "@inquirer/prompts": "^7.10.1",
     "@salesforce/ts-types": "^2.0.12",
     "zod": "^4.1.12"
   },

--- a/src/commands/simply/package/dependencies/manage.ts
+++ b/src/commands/simply/package/dependencies/manage.ts
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2026, Clay Chipps; Copyright (c) 2026 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable no-await-in-loop */
+import { select } from '@inquirer/prompts';
+import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { Messages } from '@salesforce/core';
+import { DependencyChange, PackageDependenciesManageResult } from '../../../../schemas/manage/dependencyChange.js';
+import { ParsedDependency } from '../../../../schemas/manage/parsedDependency.js';
+import { buildVersionService, VersionChoice } from '../../../../common/packageVersionService.js';
+import { buildProjectService } from '../../../../common/sfdxProjectService.js';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('@simplysf/simply-package', 'simply.package.dependencies.manage');
+
+export type { PackageDependenciesManageResult };
+
+export default class PackageDependenciesManage extends SfCommand<PackageDependenciesManageResult[]> {
+  public static readonly summary = messages.getMessage('summary');
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessages('examples');
+  public static readonly requiresProject = true;
+
+  public static readonly flags = {
+    ...SfCommand.baseFlags,
+    branch: Flags.string({
+      summary: messages.getMessage('flags.branch.summary'),
+      description: messages.getMessage('flags.branch.description'),
+      char: 'b',
+    }),
+    'update-to-released': Flags.boolean({
+      summary: messages.getMessage('flags.update-to-released.summary'),
+      description: messages.getMessage('flags.update-to-released.description'),
+      default: false,
+      exclusive: ['update-to-latest'],
+    }),
+    'update-to-latest': Flags.boolean({
+      summary: messages.getMessage('flags.update-to-latest.summary'),
+      description: messages.getMessage('flags.update-to-latest.description'),
+      default: false,
+      exclusive: ['update-to-released'],
+    }),
+    'api-version': Flags.orgApiVersion(),
+    'target-dev-hub': Flags.requiredHub(),
+  };
+
+  // eslint-disable-next-line complexity
+  public async run(): Promise<PackageDependenciesManageResult[]> {
+    const { flags } = await this.parse(PackageDependenciesManage);
+
+    const isInteractive = !flags['update-to-released'] && !flags['update-to-latest'];
+    const connection = flags['target-dev-hub'].getConnection(flags['api-version']);
+
+    this.spinner.start(messages.getMessage('info.loadingDevHubData'));
+    const versionService = await buildVersionService(connection, this.project!);
+    this.spinner.stop();
+
+    this.spinner.start(messages.getMessage('info.analyzingDependencies'));
+    const projectService = await buildProjectService(this.project!);
+    const dependenciesByDirectory = projectService.getDependenciesByDirectory();
+    const dependenciesToIgnore = projectService.getDependenciesToIgnore();
+    const branchesWithReleased = projectService.getBranchesWithReleasedVersions();
+    this.spinner.stop();
+
+    const changesByDirectory = new Map<string, DependencyChange[]>();
+    const results: PackageDependenciesManageResult[] = [];
+
+    for (const [dirPath, dependencies] of dependenciesByDirectory) {
+      changesByDirectory.set(dirPath, []);
+      const dirResults: PackageDependenciesManageResult = { packageDirectory: dirPath, changes: [] };
+
+      for (const rawDependency of dependencies) {
+        const dependency = versionService.enrichDependency(rawDependency);
+        const package2Id = dependency.package2Id;
+
+        const dependencyDisplayName = buildDisplayName(dependency, projectService.findAlias.bind(projectService));
+
+        this.info('');
+
+        if (
+          !package2Id ||
+          (!versionService.knowsAboutPackage(package2Id) &&
+            !versionService.knowsAboutVersion(dependency.subscriberPackageVersionId ?? ''))
+        ) {
+          this.info(messages.getMessage('info.dependencyNotManagedByDevHub', [dependencyDisplayName]));
+          const oldAlias =
+            projectService.findAlias(dependency.subscriberPackageVersionId ?? dependency.package2Id ?? '') ??
+            dependencyDisplayName;
+          changesByDirectory.get(dirPath)!.push({
+            oldAlias,
+            oldDependency: dependency,
+            newAlias: oldAlias,
+            newSubscriberPackageVersionId: dependency.subscriberPackageVersionId,
+            newPackage2Id: dependency.package2Id,
+            newVersionNumber: dependency.versionNumber,
+            isSameAsOld: true,
+          });
+          dirResults.changes.push({ oldAlias, newAlias: oldAlias, changed: false });
+          continue;
+        }
+
+        this.info(messages.getMessage('info.reviewingDependency', [dependencyDisplayName]));
+
+        const oldAlias =
+          versionService.getVersionAlias(dependency.subscriberPackageVersionId ?? '') ??
+          projectService.findAlias(dependency.subscriberPackageVersionId ?? dependency.package2Id ?? '') ??
+          dependencyDisplayName;
+
+        const isIgnored =
+          dependenciesToIgnore.includes(package2Id) ||
+          dependenciesToIgnore.includes(versionService.getPackageAlias(package2Id) ?? '');
+
+        let choices: VersionChoice[] = [];
+
+        if (isIgnored) {
+          choices =
+            dependency.subscriberPackageVersionId &&
+            versionService.knowsAboutVersion(dependency.subscriberPackageVersionId)
+              ? [{ name: 'Current version specified', value: dependency.subscriberPackageVersionId, short: oldAlias }]
+              : [];
+        } else if (isInteractive) {
+          choices = versionService.buildInteractiveChoices(dependency, flags.branch ?? '', branchesWithReleased);
+        } else if (flags['update-to-released']) {
+          choices = versionService.buildReleasedChoices(dependency, branchesWithReleased);
+        } else {
+          choices = versionService.buildLatestChoices(dependency);
+        }
+
+        this.info('');
+
+        if (choices.length === 0) {
+          this.info(messages.getMessage('info.noAlternatesFound', [dependencyDisplayName]));
+          dirResults.changes.push({ oldAlias, newAlias: oldAlias, changed: false });
+          continue;
+        }
+
+        let selectedValue: string;
+
+        if (isInteractive && !isIgnored) {
+          const packageDisplayName = versionService.getPackageAlias(package2Id) ?? package2Id;
+          selectedValue = await this.promptForVersion(
+            messages.getMessage('prompt.selectVersion', [packageDisplayName]),
+            choices
+          );
+        } else {
+          selectedValue = choices[0].value;
+        }
+
+        const change = buildChange(
+          oldAlias,
+          dependency,
+          selectedValue,
+          versionService.getVersionAlias.bind(versionService),
+          versionService.getPackage2IdForVersion.bind(versionService)
+        );
+        changesByDirectory.get(dirPath)!.push(change);
+
+        if (isIgnored) {
+          this.info(messages.getMessage('info.versionIgnored', [dependencyDisplayName]));
+        } else {
+          this.info(messages.getMessage('info.versionSelected', [dependencyDisplayName, change.newAlias]));
+        }
+
+        dirResults.changes.push({ oldAlias, newAlias: change.newAlias, changed: !change.isSameAsOld });
+        this.info('');
+        this.info('*'.repeat(88));
+        this.info('');
+      }
+
+      results.push(dirResults);
+    }
+
+    await projectService.applyChanges(changesByDirectory);
+    return results;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  protected async promptForVersion(message: string, choices: VersionChoice[]): Promise<string> {
+    return select({ message, choices, pageSize: 8 });
+  }
+}
+
+function buildDisplayName(dependency: ParsedDependency, findAlias: (id: string) => string | undefined): string {
+  if (dependency.subscriberPackageVersionId) {
+    const alias = findAlias(dependency.subscriberPackageVersionId);
+    return alias ? `${alias} (${dependency.subscriberPackageVersionId})` : dependency.subscriberPackageVersionId;
+  }
+  if (dependency.package2Id && dependency.versionNumber) {
+    const alias = findAlias(dependency.package2Id);
+    const base = alias ? `${alias} (${dependency.package2Id})` : dependency.package2Id;
+    return `${base} version ${dependency.versionNumber}`;
+  }
+  return '<unknown dependency>';
+}
+
+function buildChange(
+  oldAlias: string,
+  oldDependency: ParsedDependency,
+  selectedValue: string,
+  getVersionAlias: (id: string) => string | undefined,
+  getPackage2Id: (id: string) => string | undefined
+): DependencyChange {
+  // Pinned selection: value is a SubscriberPackageVersionId (04t)
+  if (selectedValue.startsWith('04t')) {
+    const newAlias = getVersionAlias(selectedValue) ?? selectedValue;
+    const newPackage2Id = getPackage2Id(selectedValue);
+    return {
+      oldAlias,
+      oldDependency,
+      newAlias,
+      newSubscriberPackageVersionId: selectedValue,
+      newPackage2Id,
+      isSameAsOld: selectedValue === oldDependency.subscriberPackageVersionId,
+    };
+  }
+
+  // Non-pinned selection: value is "package2Id|major.minor.patch.LATEST"
+  const [package2Id, versionNumber] = selectedValue.split('|');
+  const newAlias = (getVersionAlias(package2Id) ?? package2Id) + '@' + versionNumber;
+  return {
+    oldAlias,
+    oldDependency,
+    newAlias,
+    newPackage2Id: package2Id,
+    newVersionNumber: versionNumber,
+    isSameAsOld: package2Id === oldDependency.package2Id && versionNumber === oldDependency.versionNumber,
+  };
+}

--- a/src/common/packageVersionService.ts
+++ b/src/common/packageVersionService.ts
@@ -1,0 +1,398 @@
+/*
+ * Copyright (c) 2026, Clay Chipps; Copyright (c) 2026 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Connection } from '@salesforce/core';
+import { SfProject } from '@salesforce/core';
+import { Package, PackageVersionListResult, PackagingSObjects } from '@salesforce/packaging';
+import { ParsedDependency } from '../schemas/manage/parsedDependency.js';
+
+export type VersionChoice = {
+  name: string;
+  value: string;
+  short: string;
+};
+
+// Map structure: Package2Id → Branch → Major → Minor → Patch → Build → PackageVersionListResult
+type VersionMap = Map<
+  string,
+  Map<string, Map<number, Map<number, Map<number, Map<number, PackageVersionListResult>>>>>
+>;
+
+export type PackageVersionService = {
+  knowsAboutVersion(subscriberPackageVersionId: string): boolean;
+  knowsAboutPackage(package2Id: string): boolean;
+  getPackage2IdForVersion(subscriberPackageVersionId: string): string | undefined;
+  getVersionAlias(subscriberPackageVersionId: string): string | undefined;
+  getPackageAlias(package2Id: string): string | undefined;
+  enrichDependency(dependency: ParsedDependency): ParsedDependency;
+  buildInteractiveChoices(
+    dependency: ParsedDependency,
+    branch: string,
+    branchesWithReleased: string[]
+  ): VersionChoice[];
+  buildReleasedChoices(dependency: ParsedDependency, branchesWithReleased: string[]): VersionChoice[];
+  buildLatestChoices(dependency: ParsedDependency): VersionChoice[];
+  findVersionById(subscriberPackageVersionId: string): PackageVersionListResult | undefined;
+};
+
+export async function buildVersionService(connection: Connection, project: SfProject): Promise<PackageVersionService> {
+  const packages = await Package.list(connection);
+  const versions = await Package.listVersions(connection, project, {
+    concise: false,
+    createdLastDays: undefined as unknown as number,
+    modifiedLastDays: undefined as unknown as number,
+    orderBy: 'Package2Id, Branch, MajorVersion, MinorVersion, PatchVersion, BuildNumber',
+    isReleased: undefined,
+    verbose: true,
+  });
+
+  const versionsBySubscriberId = new Map<string, PackageVersionListResult>();
+  const packageAliasById = new Map<string, string>();
+  const versionsByPackageAndBranch: VersionMap = new Map();
+  const releasedVersionsByPackageAndBranch: VersionMap = new Map();
+
+  for (const pkg of packages) {
+    packageAliasById.set(pkg.Id, computePackageAlias(pkg));
+  }
+
+  for (const version of versions) {
+    versionsBySubscriberId.set(version.SubscriberPackageVersionId, version);
+    sortVersionIntoMap(versionsByPackageAndBranch, version);
+    if (version.IsReleased) {
+      sortVersionIntoMap(releasedVersionsByPackageAndBranch, version);
+    }
+  }
+
+  function computePackageAlias(pkg: PackagingSObjects.Package2): string {
+    return (pkg.NamespacePrefix ? pkg.NamespacePrefix + '.' : '') + pkg.Name;
+  }
+
+  function computeVersionAlias(v: PackageVersionListResult, branch?: string): string {
+    const seg = `${v.MajorVersion}.${v.MinorVersion}.${v.PatchVersion}-${v.BuildNumber}` + (branch ? '-' + branch : '');
+    const pkgAlias = packageAliasById.get(v.Package2Id) ?? v.Package2Id;
+    return pkgAlias + '@' + seg;
+  }
+
+  function sortVersionIntoMap(map: VersionMap, v: PackageVersionListResult): void {
+    const branch = v.Branch ?? '';
+    const major = parseInt(v.MajorVersion, 10);
+    const minor = parseInt(v.MinorVersion, 10);
+    const patch = parseInt(v.PatchVersion, 10);
+    const build = parseInt(v.BuildNumber, 10);
+
+    if (!map.has(v.Package2Id)) map.set(v.Package2Id, new Map());
+    const byBranch = map.get(v.Package2Id)!;
+
+    if (!byBranch.has(branch)) byBranch.set(branch, new Map());
+    const byMajor = byBranch.get(branch)!;
+
+    if (!byMajor.has(major)) byMajor.set(major, new Map());
+    const byMinor = byMajor.get(major)!;
+
+    if (!byMinor.has(minor)) byMinor.set(minor, new Map());
+    const byPatch = byMinor.get(minor)!;
+
+    if (!byPatch.has(patch)) byPatch.set(patch, new Map());
+    const byBuild = byPatch.get(patch)!;
+
+    if (!byBuild.has(build)) byBuild.set(build, v);
+  }
+
+  // Walks a version map block to the latest (highest-key) entry at any depth
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function findLatestFromBlock(block: Map<number, any>): PackageVersionListResult {
+    const keys = [...block.keys()];
+    const maxKey = keys.reduce((max, k) => (k > max ? k : max), keys[0]);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const entry = block.get(maxKey);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    return entry instanceof Map ? findLatestFromBlock(entry) : (entry as PackageVersionListResult);
+  }
+
+  enum ChunkLevel {
+    Major = 1,
+    Minor,
+    Patch,
+  }
+
+  function findBlock(
+    map: VersionMap,
+    package2Id: string,
+    branch: string,
+    dependency: ParsedDependency,
+    level: ChunkLevel
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): Map<number, any> | undefined {
+    const resolvedBranch = branch ?? '';
+    const byBranch = map.get(package2Id);
+    if (!byBranch?.has(resolvedBranch)) return undefined;
+
+    const byMajor = byBranch.get(resolvedBranch);
+    if (level === ChunkLevel.Major) return byMajor;
+
+    const byMinor = byMajor?.get(dependency.majorVersion!);
+    if (level === ChunkLevel.Minor || byMinor === undefined) return byMinor;
+
+    return byMinor.get(dependency.minorVersion!);
+  }
+
+  function makeVersionChoice(v: PackageVersionListResult, label: string, branch?: string): VersionChoice {
+    const seg = `${v.MajorVersion}.${v.MinorVersion}.${v.PatchVersion}-${v.BuildNumber}` + (branch ? '-' + branch : '');
+    return {
+      name: `${label}: ${seg}`,
+      value: v.SubscriberPackageVersionId,
+      short: seg,
+    };
+  }
+
+  function makeLatestChoice(v: PackageVersionListResult, label: string): VersionChoice {
+    const seg = `${v.MajorVersion}.${v.MinorVersion}.${v.PatchVersion}.LATEST`;
+    return {
+      name: label,
+      value: `${v.Package2Id}|${seg}`,
+      short: seg,
+    };
+  }
+
+  function findLatestReleasedForBranch(
+    package2Id: string,
+    branch: string,
+    dependency: ParsedDependency,
+    seen: Set<string>
+  ): VersionChoice | undefined {
+    const block = findBlock(releasedVersionsByPackageAndBranch, package2Id, branch, dependency, ChunkLevel.Major);
+    if (!block) return undefined;
+    const v = findLatestFromBlock(block);
+    if (seen.has(v.SubscriberPackageVersionId)) return undefined;
+    seen.add(v.SubscriberPackageVersionId);
+    const label = branch
+      ? `Latest released version on build branch - ${branch}`
+      : 'Latest released version on main build branch';
+    return makeVersionChoice(v, label, branch || undefined);
+  }
+
+  function findLatestForBranch(
+    package2Id: string,
+    branch: string,
+    dependency: ParsedDependency,
+    level: ChunkLevel,
+    label: string,
+    seen: Set<string>
+  ): VersionChoice | undefined {
+    const block = findBlock(versionsByPackageAndBranch, package2Id, branch, dependency, level);
+    if (!block) return undefined;
+    const v = findLatestFromBlock(block);
+    if (seen.has(v.SubscriberPackageVersionId)) return undefined;
+    seen.add(v.SubscriberPackageVersionId);
+    return makeVersionChoice(v, label, branch || undefined);
+  }
+
+  return {
+    knowsAboutVersion(id: string): boolean {
+      return versionsBySubscriberId.has(id);
+    },
+
+    knowsAboutPackage(package2Id: string): boolean {
+      return packageAliasById.has(package2Id);
+    },
+
+    getPackage2IdForVersion(subscriberPackageVersionId: string): string | undefined {
+      return versionsBySubscriberId.get(subscriberPackageVersionId)?.Package2Id;
+    },
+
+    getVersionAlias(subscriberPackageVersionId: string): string | undefined {
+      const v = versionsBySubscriberId.get(subscriberPackageVersionId);
+      if (!v) return undefined;
+      return computeVersionAlias(v, v.Branch || undefined);
+    },
+
+    getPackageAlias(package2Id: string): string | undefined {
+      return packageAliasById.get(package2Id);
+    },
+
+    findVersionById(subscriberPackageVersionId: string): PackageVersionListResult | undefined {
+      return versionsBySubscriberId.get(subscriberPackageVersionId);
+    },
+
+    enrichDependency(dependency: ParsedDependency): ParsedDependency {
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+      if (dependency.package2Id || !dependency.subscriberPackageVersionId) return dependency;
+      const v = versionsBySubscriberId.get(dependency.subscriberPackageVersionId);
+      if (!v) return dependency;
+      const parts = `${v.MajorVersion}.${v.MinorVersion}.${v.PatchVersion}.${v.BuildNumber}`.split('.');
+      return {
+        ...dependency,
+        package2Id: v.Package2Id,
+        versionNumber: `${v.MajorVersion}.${v.MinorVersion}.${v.PatchVersion}.${v.BuildNumber}`,
+        majorVersion: parseInt(parts[0], 10),
+        minorVersion: parseInt(parts[1], 10),
+        patchVersion: parseInt(parts[2], 10),
+        buildVersion: parseInt(parts[3], 10),
+      };
+    },
+
+    // eslint-disable-next-line complexity
+    buildInteractiveChoices(
+      dependency: ParsedDependency,
+      branch: string,
+      branchesWithReleased: string[]
+    ): VersionChoice[] {
+      const package2Id = dependency.package2Id!;
+      const maj = dependency.majorVersion ?? '';
+      const min = dependency.minorVersion ?? '';
+      const pat = dependency.patchVersion ?? '';
+      const choices: VersionChoice[] = [];
+      const releasedChoices: VersionChoice[] = [];
+      const seen = new Set<string>();
+
+      // Latest released on null/main branch and named release branches
+      const releasedMain = findLatestReleasedForBranch(package2Id, '', dependency, seen);
+      if (releasedMain) releasedChoices.push(releasedMain);
+      for (const b of branchesWithReleased ?? []) {
+        const rc = findLatestReleasedForBranch(package2Id, b, dependency, seen);
+        if (rc) releasedChoices.push(rc);
+      }
+
+      // Latest version on the specified feature branch
+      if (branch) {
+        const c = findLatestForBranch(
+          package2Id,
+          branch,
+          dependency,
+          ChunkLevel.Patch,
+          `Latest version on '${branch}' branch`,
+          seen
+        );
+        if (c) choices.push(c);
+      }
+
+      // Latest build with same Major.Minor.Patch on main branch and release branches
+      const patchMain = findLatestForBranch(
+        package2Id,
+        '',
+        dependency,
+        ChunkLevel.Patch,
+        `Latest ${maj}.${min}.${pat} version on main build branch`,
+        seen
+      );
+      if (patchMain) choices.push(patchMain);
+      for (const b of branchesWithReleased ?? []) {
+        const c = findLatestForBranch(
+          package2Id,
+          b,
+          dependency,
+          ChunkLevel.Patch,
+          `Latest ${maj}.${min}.${pat} version on build branch - ${b}`,
+          seen
+        );
+        if (c) choices.push(c);
+      }
+
+      // Latest build with same Major.Minor on main branch and release branches
+      const minorMain = findLatestForBranch(
+        package2Id,
+        '',
+        dependency,
+        ChunkLevel.Minor,
+        `Latest ${maj}.${min} version on main build branch`,
+        seen
+      );
+      if (minorMain) choices.push(minorMain);
+      for (const b of branchesWithReleased ?? []) {
+        const c = findLatestForBranch(
+          package2Id,
+          b,
+          dependency,
+          ChunkLevel.Minor,
+          `Latest ${maj}.${min} version on build branch - ${b}`,
+          seen
+        );
+        if (c) choices.push(c);
+      }
+
+      // Latest build overall on main branch and release branches
+      const majorMain = findLatestForBranch(
+        package2Id,
+        '',
+        dependency,
+        ChunkLevel.Major,
+        'Latest version on main build branch',
+        seen
+      );
+      if (majorMain) choices.push(majorMain);
+      for (const b of branchesWithReleased ?? []) {
+        const c = findLatestForBranch(
+          package2Id,
+          b,
+          dependency,
+          ChunkLevel.Major,
+          `Latest version on build branch - ${b}`,
+          seen
+        );
+        if (c) choices.push(c);
+      }
+
+      // Released choices go after so they appear clearly
+      choices.push(...releasedChoices);
+
+      // Non-pinned latest for current Major.Minor.Patch
+      const block =
+        findBlock(versionsByPackageAndBranch, package2Id, branch, dependency, ChunkLevel.Patch) ??
+        findBlock(versionsByPackageAndBranch, package2Id, '', dependency, ChunkLevel.Patch) ??
+        findBlock(versionsByPackageAndBranch, package2Id, '', dependency, ChunkLevel.Minor);
+      if (block) {
+        const v = findLatestFromBlock(block);
+        choices.push(makeLatestChoice(v, `Non-pinned latest ${maj}.${min}.${pat} build`));
+      }
+
+      // Keep the current version as last option
+      if (dependency.subscriberPackageVersionId && versionsBySubscriberId.has(dependency.subscriberPackageVersionId)) {
+        const v = versionsBySubscriberId.get(dependency.subscriberPackageVersionId)!;
+        choices.push(makeVersionChoice(v, 'Current version specified', v.Branch || undefined));
+      }
+
+      return choices;
+    },
+
+    buildReleasedChoices(dependency: ParsedDependency, branchesWithReleased: string[]): VersionChoice[] {
+      const package2Id = dependency.package2Id!;
+      const choices: VersionChoice[] = [];
+      const seen = new Set<string>();
+
+      const main = findLatestReleasedForBranch(package2Id, '', dependency, seen);
+      if (main) choices.push(main);
+      for (const b of branchesWithReleased ?? []) {
+        const c = findLatestReleasedForBranch(package2Id, b, dependency, seen);
+        if (c) choices.push(c);
+      }
+
+      return choices;
+    },
+
+    buildLatestChoices(dependency: ParsedDependency): VersionChoice[] {
+      const package2Id = dependency.package2Id!;
+      const block =
+        findBlock(versionsByPackageAndBranch, package2Id, '', dependency, ChunkLevel.Patch) ??
+        findBlock(versionsByPackageAndBranch, package2Id, '', dependency, ChunkLevel.Minor);
+      if (!block) return [];
+      const v = findLatestFromBlock(block);
+      const maj = dependency.majorVersion ?? '';
+      const min = dependency.minorVersion ?? '';
+      const pat = dependency.patchVersion ?? '';
+      return [makeLatestChoice(v, `Non-pinned latest ${maj}.${min}.${pat} build`)];
+    },
+  };
+}

--- a/src/common/sfdxProjectService.ts
+++ b/src/common/sfdxProjectService.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { SfProject } from '@salesforce/core';
+import { SfProject, isNamedPackagingDirectory } from '@salesforce/core';
 import { DependencyChange } from '../schemas/manage/dependencyChange.js';
 import { ParsedDependency, parseDependency } from '../schemas/manage/parsedDependency.js';
 import { PACKAGE_PREFIX_SUBSCRIBER_PACKAGE_VERSION } from './packageUtils.js';
@@ -37,8 +37,7 @@ export async function buildProjectService(project: SfProject): Promise<SfdxProje
   }
 
   function resolveAlias(alias: string): string {
-    const aliases = getAliases();
-    return aliases[alias] ?? alias;
+    return project.getPackageIdFromAlias(alias) ?? alias;
   }
 
   function findAlias(id: string): string | undefined {
@@ -51,21 +50,17 @@ export async function buildProjectService(project: SfProject): Promise<SfdxProje
 
   function getDependenciesByDirectory(): Map<string, ParsedDependency[]> {
     const result = new Map<string, ParsedDependency[]>();
-    const packageDirectories = (contents.packageDirectories ?? []) as Array<Record<string, unknown>>;
 
-    for (const dir of packageDirectories) {
-      const path = dir['path'] as string;
-      const deps = (dir['dependencies'] ?? []) as Array<Record<string, string>>;
+    for (const dir of project.getPackageDirectories()) {
+      const deps = isNamedPackagingDirectory(dir) ? dir.dependencies ?? [] : [];
       const parsed: ParsedDependency[] = [];
 
       for (const dep of deps) {
-        const rawPackage = dep['package'] ?? '';
-        const versionNumber = dep['versionNumber'];
-        const resolvedPackage = resolveAlias(rawPackage);
-        parsed.push(parseDependency(resolvedPackage, versionNumber));
+        const resolvedPackage = project.getPackageIdFromAlias(dep.package) ?? dep.package;
+        parsed.push(parseDependency(resolvedPackage, dep.versionNumber));
       }
 
-      result.set(path, parsed);
+      result.set(dir.path, parsed);
     }
 
     return result;

--- a/src/common/sfdxProjectService.ts
+++ b/src/common/sfdxProjectService.ts
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2026, Clay Chipps; Copyright (c) 2026 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SfProject } from '@salesforce/core';
+import { DependencyChange } from '../schemas/manage/dependencyChange.js';
+import { ParsedDependency, parseDependency } from '../schemas/manage/parsedDependency.js';
+import { PACKAGE_PREFIX_SUBSCRIBER_PACKAGE_VERSION } from './packageUtils.js';
+
+export type SfdxProjectService = {
+  getDependenciesByDirectory(): Map<string, ParsedDependency[]>;
+  getDependenciesToIgnore(): string[];
+  getBranchesWithReleasedVersions(): string[];
+  findAlias(id: string): string | undefined;
+  resolveAlias(alias: string): string;
+  applyChanges(changesByDirectory: Map<string, DependencyChange[]>): Promise<void>;
+};
+
+export async function buildProjectService(project: SfProject): Promise<SfdxProjectService> {
+  const projectJson = await project.retrieveSfProjectJson();
+  const contents = projectJson.getContents();
+
+  function getAliases(): Record<string, string> {
+    return (contents.packageAliases as Record<string, string>) ?? {};
+  }
+
+  function resolveAlias(alias: string): string {
+    const aliases = getAliases();
+    return aliases[alias] ?? alias;
+  }
+
+  function findAlias(id: string): string | undefined {
+    const aliases = getAliases();
+    for (const [k, v] of Object.entries(aliases)) {
+      if (v === id) return k;
+    }
+    return undefined;
+  }
+
+  function getDependenciesByDirectory(): Map<string, ParsedDependency[]> {
+    const result = new Map<string, ParsedDependency[]>();
+    const packageDirectories = (contents.packageDirectories ?? []) as Array<Record<string, unknown>>;
+
+    for (const dir of packageDirectories) {
+      const path = dir['path'] as string;
+      const deps = (dir['dependencies'] ?? []) as Array<Record<string, string>>;
+      const parsed: ParsedDependency[] = [];
+
+      for (const dep of deps) {
+        const rawPackage = dep['package'] ?? '';
+        const versionNumber = dep['versionNumber'];
+        const resolvedPackage = resolveAlias(rawPackage);
+        parsed.push(parseDependency(resolvedPackage, versionNumber));
+      }
+
+      result.set(path, parsed);
+    }
+
+    return result;
+  }
+
+  function getPluginConfig<T>(keyPath: string): T | undefined {
+    const parts = keyPath.split('.');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let current: any = contents;
+    for (const part of parts) {
+      if (current == null || typeof current !== 'object') return undefined;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+      current = current[part];
+    }
+    return current as T;
+  }
+
+  function getDependenciesToIgnore(): string[] {
+    return getPluginConfig<string[]>('plugins.simply.dependencies.ignore') ?? [];
+  }
+
+  function getBranchesWithReleasedVersions(): string[] {
+    return getPluginConfig<string[]>('plugins.simply.package.brancheswithreleasedversions') ?? [];
+  }
+
+  async function applyChanges(changesByDirectory: Map<string, DependencyChange[]>): Promise<void> {
+    // Deep-clone both structures so we can mutate them freely before calling set()
+    const updatedDirs = JSON.parse(JSON.stringify(contents.packageDirectories ?? [])) as Array<Record<string, unknown>>;
+    const updatedAliases = { ...getAliases() };
+
+    for (const [dirPath, changes] of changesByDirectory) {
+      const dir = updatedDirs.find((d) => d['path'] === dirPath);
+      if (!dir) continue;
+
+      const deps = (dir['dependencies'] ?? []) as Array<Record<string, string>>;
+
+      for (const change of changes) {
+        const dep = deps.find(
+          (d) =>
+            resolveAlias(d['package']) === change.oldDependency.package2Id ||
+            resolveAlias(d['package']) === change.oldDependency.subscriberPackageVersionId
+        );
+
+        if (!dep) continue;
+
+        if (change.newSubscriberPackageVersionId) {
+          // Pinned version: set alias, clear versionNumber
+          dep['package'] = change.newAlias;
+          delete dep['versionNumber'];
+          updatedAliases[change.newAlias] = change.newSubscriberPackageVersionId;
+
+          // Add package-level alias if provided
+          if (change.newPackage2Id) {
+            const pkgAlias = change.newAlias.split('@')[0];
+            if (pkgAlias && !updatedAliases[pkgAlias]) {
+              updatedAliases[pkgAlias] = change.newPackage2Id;
+            }
+          }
+
+          // Remove old version alias if it changed and pointed to a subscriber package version
+          if (change.oldAlias !== change.newAlias) {
+            const oldTarget = updatedAliases[change.oldAlias];
+            if (oldTarget?.startsWith(PACKAGE_PREFIX_SUBSCRIBER_PACKAGE_VERSION)) {
+              delete updatedAliases[change.oldAlias];
+            }
+          }
+        } else if (change.newPackage2Id && change.newVersionNumber) {
+          // Non-pinned version: set package 0Ho alias and versionNumber
+          dep['package'] = change.newAlias;
+          dep['versionNumber'] = change.newVersionNumber;
+          updatedAliases[change.newAlias] = change.newPackage2Id;
+
+          if (change.oldAlias !== change.newAlias) {
+            const oldTarget = updatedAliases[change.oldAlias];
+            if (oldTarget?.startsWith(PACKAGE_PREFIX_SUBSCRIBER_PACKAGE_VERSION)) {
+              delete updatedAliases[change.oldAlias];
+            }
+          }
+        }
+      }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+    projectJson.set('packageDirectories', updatedDirs as any);
+    projectJson.set('packageAliases', updatedAliases);
+    await projectJson.write();
+  }
+
+  return {
+    getDependenciesByDirectory,
+    getDependenciesToIgnore,
+    getBranchesWithReleasedVersions,
+    findAlias,
+    resolveAlias,
+    applyChanges,
+  };
+}

--- a/src/schemas/manage/dependencyChange.ts
+++ b/src/schemas/manage/dependencyChange.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026, Clay Chipps; Copyright (c) 2026 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ParsedDependency } from './parsedDependency.js';
+
+export type DependencyChange = {
+  oldAlias: string;
+  oldDependency: ParsedDependency;
+  newAlias: string;
+  newSubscriberPackageVersionId?: string;
+  newPackage2Id?: string;
+  newVersionNumber?: string;
+  isSameAsOld: boolean;
+};
+
+export type PackageDependenciesManageResult = {
+  packageDirectory: string;
+  changes: Array<{
+    oldAlias: string;
+    newAlias: string;
+    changed: boolean;
+  }>;
+};

--- a/src/schemas/manage/parsedDependency.ts
+++ b/src/schemas/manage/parsedDependency.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026, Clay Chipps; Copyright (c) 2026 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PACKAGE_PREFIX_PACKAGE2, PACKAGE_PREFIX_SUBSCRIBER_PACKAGE_VERSION } from '../../common/packageUtils.js';
+
+export type ParsedDependency = {
+  subscriberPackageVersionId?: string;
+  package2Id?: string;
+  versionNumber?: string;
+  majorVersion?: number;
+  minorVersion?: number;
+  patchVersion?: number;
+  buildVersion?: number;
+  isLatest: boolean;
+  isPinned: boolean;
+};
+
+export function parseDependency(resolvedPackage: string, versionNumber?: string): ParsedDependency {
+  const result: ParsedDependency = { isLatest: false, isPinned: false };
+
+  if (resolvedPackage.startsWith(PACKAGE_PREFIX_SUBSCRIBER_PACKAGE_VERSION)) {
+    result.subscriberPackageVersionId = resolvedPackage;
+    result.isPinned = true;
+    return result;
+  }
+
+  if (resolvedPackage.startsWith(PACKAGE_PREFIX_PACKAGE2)) {
+    result.package2Id = resolvedPackage;
+    result.versionNumber = versionNumber;
+
+    const versionWorking = (versionNumber ?? '').toUpperCase().replace('-LATEST', '').replace('.LATEST', '');
+    const parts = versionWorking.split('.');
+
+    result.majorVersion = parts[0] ? parseInt(parts[0], 10) : undefined;
+    result.minorVersion = parts[1] ? parseInt(parts[1], 10) : undefined;
+    result.patchVersion = parts[2] ? parseInt(parts[2], 10) : undefined;
+    result.buildVersion = parts[3] ? parseInt(parts[3], 10) : undefined;
+    result.isLatest = (versionNumber ?? '').toUpperCase().endsWith('LATEST');
+    result.isPinned = !result.isLatest;
+    return result;
+  }
+
+  return result;
+}

--- a/test/commands/simply/package/dependencies/manage.nut.ts
+++ b/test/commands/simply/package/dependencies/manage.nut.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026, Clay Chipps; Copyright (c) 2026 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestSession } from '@salesforce/cli-plugins-testkit';
+
+describe('simply package dependencies manage', () => {
+  let session: TestSession;
+
+  before(async () => {
+    session = await TestSession.create({ devhubAuthStrategy: 'NONE' });
+  });
+
+  after(async () => {
+    await session?.clean();
+  });
+});

--- a/test/commands/simply/package/dependencies/manage.test.ts
+++ b/test/commands/simply/package/dependencies/manage.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { SfError, SfProject } from '@salesforce/core';
+import { NamedPackageDir, SfError, SfProject } from '@salesforce/core';
 import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
 import { Package, PackageVersionListResult } from '@salesforce/packaging';
 import { expect } from 'chai';
@@ -65,7 +65,20 @@ const mockVersion101: PackageVersionListResult = {
   IsReleased: false,
 };
 
-// Minimal sfdx-project.json contents where force-app depends on mockVersion100
+// Typed package directory mock. Must have a `package` property so isNamedPackagingDirectory returns true.
+const mockPackageDirectories = [
+  {
+    path: 'force-app',
+    name: 'force-app',
+    fullPath: '/test/force-app',
+    default: true,
+    package: 'MyProject',
+    versionNumber: '1.0.0.NEXT',
+    dependencies: [{ package: mockVersion100.SubscriberPackageVersionId }],
+  },
+] as unknown as NamedPackageDir[];
+
+// Minimal sfdx-project.json contents — only needed for findAlias and applyChanges.
 const mockProjectContents = {
   packageDirectories: [
     {
@@ -118,6 +131,7 @@ describe('simply package dependencies manage', () => {
   it('should auto-select latest released version with --update-to-released', async () => {
     $$.SANDBOX.stub(Package, 'list').resolves([]);
     $$.SANDBOX.stub(Package, 'listVersions').resolves([mockVersion100, mockVersion101]);
+    $$.SANDBOX.stub(SfProject.prototype, 'getPackageDirectories').returns(mockPackageDirectories);
     $$.SANDBOX.stub(SfProject.prototype, 'retrieveSfProjectJson').resolves(buildMockProjectJson() as never);
 
     const results = await PackageDependenciesManage.run(['--target-dev-hub', testOrg.username, '--update-to-released']);
@@ -131,6 +145,7 @@ describe('simply package dependencies manage', () => {
   it('should auto-select non-pinned latest with --update-to-latest', async () => {
     $$.SANDBOX.stub(Package, 'list').resolves([]);
     $$.SANDBOX.stub(Package, 'listVersions').resolves([mockVersion100, mockVersion101]);
+    $$.SANDBOX.stub(SfProject.prototype, 'getPackageDirectories').returns(mockPackageDirectories);
     $$.SANDBOX.stub(SfProject.prototype, 'retrieveSfProjectJson').resolves(buildMockProjectJson() as never);
 
     const results = await PackageDependenciesManage.run(['--target-dev-hub', testOrg.username, '--update-to-latest']);
@@ -143,6 +158,7 @@ describe('simply package dependencies manage', () => {
   it('should prompt user in interactive mode and apply selection', async () => {
     $$.SANDBOX.stub(Package, 'list').resolves([]);
     $$.SANDBOX.stub(Package, 'listVersions').resolves([mockVersion100, mockVersion101]);
+    $$.SANDBOX.stub(SfProject.prototype, 'getPackageDirectories').returns(mockPackageDirectories);
     $$.SANDBOX.stub(SfProject.prototype, 'retrieveSfProjectJson').resolves(buildMockProjectJson() as never);
     // Simulate user picking the 1.0.1-1 version (stub prototype method to avoid ESM restriction)
     $$.SANDBOX.stub(PackageDependenciesManage.prototype, 'promptForVersion' as never).resolves(
@@ -159,6 +175,7 @@ describe('simply package dependencies manage', () => {
   it('should skip and mark unchanged when dev hub has no versions', async () => {
     $$.SANDBOX.stub(Package, 'list').resolves([]);
     $$.SANDBOX.stub(Package, 'listVersions').resolves([]);
+    $$.SANDBOX.stub(SfProject.prototype, 'getPackageDirectories').returns(mockPackageDirectories);
     $$.SANDBOX.stub(SfProject.prototype, 'retrieveSfProjectJson').resolves(buildMockProjectJson() as never);
 
     const results = await PackageDependenciesManage.run(['--target-dev-hub', testOrg.username, '--update-to-released']);

--- a/test/commands/simply/package/dependencies/manage.test.ts
+++ b/test/commands/simply/package/dependencies/manage.test.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2026, Clay Chipps; Copyright (c) 2026 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SfError, SfProject } from '@salesforce/core';
+import { MockTestOrgData, TestContext } from '@salesforce/core/testSetup';
+import { Package, PackageVersionListResult } from '@salesforce/packaging';
+import { expect } from 'chai';
+import PackageDependenciesManage from '../../../../../src/commands/simply/package/dependencies/manage.js';
+
+const mockPackage2Id = '0Hot0000000YzlxBAB';
+
+const mockVersion100: PackageVersionListResult = {
+  Id: 'id-100',
+  Package2Id: mockPackage2Id,
+  SubscriberPackageVersionId: '04t100000000000AAA',
+  Name: 'v1.0.0.1',
+  // @ts-ignore
+  Package2: { Name: 'MyPackage', NamespacePrefix: '' },
+  Description: '',
+  Tag: '',
+  Branch: '',
+  MajorVersion: '1',
+  MinorVersion: '0',
+  PatchVersion: '0',
+  BuildNumber: '1',
+  IsReleased: true,
+  CreatedDate: '2024-01-01',
+  LastModifiedDate: '2024-01-01',
+  IsPasswordProtected: false,
+  AncestorId: '',
+  ValidationSkipped: false,
+  CreatedById: '',
+  // @ts-ignore
+  CodeCoverage: undefined,
+  HasPassedCodeCoverageCheck: true,
+  ConvertedFromVersionId: '',
+  ReleaseVersion: '',
+  BuildDurationInSeconds: 60,
+  HasMetadataRemoved: false,
+  Language: '',
+};
+
+const mockVersion101: PackageVersionListResult = {
+  ...mockVersion100,
+  Id: 'id-101',
+  SubscriberPackageVersionId: '04t100000000001AAA',
+  Name: 'v1.0.1.1',
+  MajorVersion: '1',
+  MinorVersion: '0',
+  PatchVersion: '1',
+  BuildNumber: '1',
+  IsReleased: false,
+};
+
+// Minimal sfdx-project.json contents where force-app depends on mockVersion100
+const mockProjectContents = {
+  packageDirectories: [
+    {
+      path: 'force-app',
+      default: true,
+      dependencies: [{ package: mockVersion100.SubscriberPackageVersionId }],
+    },
+  ],
+  packageAliases: {
+    MyPackage: mockPackage2Id,
+    'MyPackage@1.0.0-1': mockVersion100.SubscriberPackageVersionId,
+  },
+  namespace: '',
+  sourceApiVersion: '62.0',
+};
+
+function buildMockProjectJson(contents = mockProjectContents) {
+  return {
+    getContents: () => contents,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
+    set: (_key: string, _value: any) => {},
+    write: async () => contents,
+  };
+}
+
+describe('simply package dependencies manage', () => {
+  const $$ = new TestContext();
+  const testOrg = new MockTestOrgData();
+  testOrg.isDevHub = true;
+
+  before(async () => {
+    await $$.stubAuths(testOrg);
+  });
+
+  afterEach(() => {
+    $$.restore();
+  });
+
+  it('should error without required --target-dev-hub flag', async () => {
+    try {
+      await PackageDependenciesManage.run();
+      expect.fail('should have thrown NoDefaultDevHubError');
+    } catch (err) {
+      const error = err as SfError;
+      expect(error.name).to.equal('NoDefaultDevHubError');
+      expect(error.message).to.include('No default dev hub found.');
+    }
+  });
+
+  it('should auto-select latest released version with --update-to-released', async () => {
+    $$.SANDBOX.stub(Package, 'list').resolves([]);
+    $$.SANDBOX.stub(Package, 'listVersions').resolves([mockVersion100, mockVersion101]);
+    $$.SANDBOX.stub(SfProject.prototype, 'retrieveSfProjectJson').resolves(buildMockProjectJson() as never);
+
+    const results = await PackageDependenciesManage.run(['--target-dev-hub', testOrg.username, '--update-to-released']);
+
+    expect(results).to.have.length(1);
+    expect(results[0].packageDirectory).to.equal('force-app');
+    // Released version is 1.0.0-1 → isSameAsOld because current IS the released version
+    expect(results[0].changes[0].newAlias).to.include('1.0.0-1');
+  });
+
+  it('should auto-select non-pinned latest with --update-to-latest', async () => {
+    $$.SANDBOX.stub(Package, 'list').resolves([]);
+    $$.SANDBOX.stub(Package, 'listVersions').resolves([mockVersion100, mockVersion101]);
+    $$.SANDBOX.stub(SfProject.prototype, 'retrieveSfProjectJson').resolves(buildMockProjectJson() as never);
+
+    const results = await PackageDependenciesManage.run(['--target-dev-hub', testOrg.username, '--update-to-latest']);
+
+    expect(results).to.have.length(1);
+    expect(results[0].changes[0].newAlias).to.include('LATEST');
+    expect(results[0].changes[0].changed).to.equal(true);
+  });
+
+  it('should prompt user in interactive mode and apply selection', async () => {
+    $$.SANDBOX.stub(Package, 'list').resolves([]);
+    $$.SANDBOX.stub(Package, 'listVersions').resolves([mockVersion100, mockVersion101]);
+    $$.SANDBOX.stub(SfProject.prototype, 'retrieveSfProjectJson').resolves(buildMockProjectJson() as never);
+    // Simulate user picking the 1.0.1-1 version (stub prototype method to avoid ESM restriction)
+    $$.SANDBOX.stub(PackageDependenciesManage.prototype, 'promptForVersion' as never).resolves(
+      mockVersion101.SubscriberPackageVersionId
+    );
+
+    const results = await PackageDependenciesManage.run(['--target-dev-hub', testOrg.username]);
+
+    expect(results).to.have.length(1);
+    expect(results[0].changes[0].newAlias).to.include('1.0.1-1');
+    expect(results[0].changes[0].changed).to.equal(true);
+  });
+
+  it('should skip and mark unchanged when dev hub has no versions', async () => {
+    $$.SANDBOX.stub(Package, 'list').resolves([]);
+    $$.SANDBOX.stub(Package, 'listVersions').resolves([]);
+    $$.SANDBOX.stub(SfProject.prototype, 'retrieveSfProjectJson').resolves(buildMockProjectJson() as never);
+
+    const results = await PackageDependenciesManage.run(['--target-dev-hub', testOrg.username, '--update-to-released']);
+
+    expect(results).to.have.length(1);
+    expect(results[0].changes[0].changed).to.equal(false);
+  });
+});


### PR DESCRIPTION
## Summary

Migrates the `toolbox package dependencies manage` command from `sfdx-toolbox-package-utils` to this plugin, modernized to match the architectural patterns already established in `@simplysf/simply-package`.

- Replaces `SfdxCommand` (outdated) with `SfCommand<T>` from `@salesforce/sf-plugins-core`
- Replaces deprecated `salesforce-alm` CLI invocations with direct `@salesforce/packaging` API calls (`Package.list`, `Package.listVersions`)
- Replaces `inquirer` with `@inquirer/prompts`
- Converts JSON message files to Markdown `.md` format
- Uses `SfProject.getPackageDirectories()` and `SfProject.getPackageIdFromAlias()` from `@salesforce/core` where they provide typed access without unsafe casts

## New files

| File | Purpose |
|------|---------|
| `src/commands/simply/package/dependencies/manage.ts` | Command entry point |
| `src/common/packageVersionService.ts` | Queries Dev Hub; builds nested version map; provides choice builders |
| `src/common/sfdxProjectService.ts` | Reads and writes `sfdx-project.json` dependencies and aliases |
| `src/schemas/manage/parsedDependency.ts` | `ParsedDependency` type + parser |
| `src/schemas/manage/dependencyChange.ts` | `DependencyChange` and `PackageDependenciesManageResult` types |
| `messages/simply.package.dependencies.manage.md` | Command messages |
| `test/commands/simply/package/dependencies/manage.test.ts` | Unit tests |
| `test/commands/simply/package/dependencies/manage.nut.ts` | NUT shell |

## How it works

The command reads all `packageDirectories` from `sfdx-project.json`, resolves each dependency against the Dev Hub's package/version catalog, and either prompts interactively or auto-selects based on flags. Changes are written back to `sfdx-project.json` via `SfProjectJson.set()` + `.write()`.

**Three modes:**

| Mode | Flag | Behavior |
|------|------|---------|
| Interactive | _(none)_ | `@inquirer/prompts` select list per dependency |
| Released | `--update-to-released` | Auto-selects latest released version |
| Latest | `--update-to-latest` | Auto-sets non-pinned `X.Y.Z.LATEST` version number |

**sfdx-project.json config keys read by the command:**

```json
{
  "plugins": {
    "simply": {
      "dependencies": {
        "ignore": ["0Hot000000000001AAA"]
      },
      "package": {
        "brancheswithreleasedversions": ["release/spring-26"]
      }
    }
  }
}
```

## Key architectural decisions

**`packageVersionService` factory (replaces `DevHubDependencies` class + `force_package.ts`)**

Preserves the original five-level nested `Map` structure (`Package2Id → Branch → Major → Minor → Patch → Build → PackageVersionListResult`) for fast version lookup, but replaces the obsolete `salesforce-alm` CLI calls with `Package.list(connection)` and `Package.listVersions(connection, project, options)`.

**`sfdxProjectService` factory (replaces `SfdxProjects` class)**

Uses `@salesforce/core` APIs where they provide proper typing:

- `project.getPackageDirectories()` — returns `NamedPackageDir[]` with a typed `dependencies` field, eliminating `as Array<Record<string, unknown>>` casts. `isNamedPackagingDirectory()` type guard is used to safely narrow to the packaging dir variant before accessing `dependencies`.
- `project.getPackageIdFromAlias(alias)` — resolves an alias to its package ID, replacing manual alias map lookup.

The remaining methods (`findAlias`, `getDependenciesToIgnore`, `getBranchesWithReleasedVersions`, `applyChanges`) still use `projectJson` from `retrieveSfProjectJson()` directly. No high-level `@salesforce/core` equivalents exist for reverse alias lookup, arbitrary plugin config access, or writing modified `packageDirectories`/`packageAliases` back to disk.

**ESM-safe test stubs**

Named ESM exports cannot be stubbed by Sinon. Tests avoid this by stubbing at the class level:
- `Package.list` / `Package.listVersions` — class static methods
- `SfProject.prototype.getPackageDirectories` — returns typed `NamedPackageDir[]` mock with `package` property set so `isNamedPackagingDirectory` passes
- `SfProject.prototype.retrieveSfProjectJson` — returns a mock `SfProjectJson`-like object for `findAlias` and `applyChanges`
- `PackageDependenciesManage.prototype.promptForVersion` — protected wrapper method added for testability, avoiding direct stubbing of the `@inquirer/prompts` ESM export